### PR TITLE
Types are compared ahead of equality comparisons

### DIFF
--- a/src/WellBehavedPython/BaseExpect.py
+++ b/src/WellBehavedPython/BaseExpect.py
@@ -22,11 +22,27 @@ class BaseExpect:
     def __init__(self, actual):
         self.actual = actual
 
-    def toEqual(self, expected):        
+    def toEqual(self, expected):
+        self.compareTypes(expected)
         message = self.buildMessage("to equal", expected);
         if self.actual == expected:
             self.success(message)
         else:        
             self.fail(message)
+
+    def compareTypes(self, expected):
+        
+        # We want to compare types first. We also want this to
+        # bypass the usual overriding of type comparison semantics.
+        # Otherwise Expect(5).Not.toBeGreaterThan("6") will pass, when
+        # it should really fail not (5 > "6") would throw an exception
+        # and we should keep the same sematics here.
+
+        actualType = type(self.actual)
+        expectedType = type(expected)
+
+        message = "Cannot compare instance of {} to instance of {} because their types differ".format(
+            actualType, expectedType)
+        assert actualType == expectedType, message
 
 

--- a/tests/ExpectNotTests.py
+++ b/tests/ExpectNotTests.py
@@ -35,7 +35,8 @@ class ExpectNotTests(TestCase):
             "test_equals_doesnt_raise_if_numbers_unequal",
             "test_equals_raises_correctly_if_numbers_equal",
             "test_equals_doesnt_raise_if_two_strings_unequal",
-            "test_equals_raises_correctly_if_strings_equal"
+            "test_equals_raises_correctly_if_strings_equal",
+            "test_expecting_string1_not_to_equal_double1_fails"
             ]
         
         suite = TestSuite()
@@ -87,6 +88,18 @@ class ExpectNotTests(TestCase):
         
         assert raised, "Expected exception to be thrown"
         Expect(message).toEqual("Expected asdf not to equal asdf")        
+
+    def test_expecting_string1_not_to_equal_double1_fails(self):
+        caught = False
+        try:
+            Expect("1").toEqual(1)
+        except AssertionError as ex:
+            caught = True
+            Expect(ex.args[0]).toEqual("Cannot compare instance of <class 'str'> to "
+                                       + "instance of <class 'int'> because their types differ")
+        
+        assert caught, "Expected expect to fail"
+
 
 if __name__ == "__main__":
     suite = ExpectNotTests.suite()

--- a/tests/ExpectTests.py
+++ b/tests/ExpectTests.py
@@ -35,7 +35,8 @@ class ExpectTests(TestCase):
             "test_equals_raises_with_right_message_if_numeric_items_not_equal",
             "test_equals_doesnt_raise_if_string_items_are_equal",
             "test_equals_raises_with_right_message_if_string_items_not_equal",
-            "test_expects_not_toequal_behaves_correctly"
+            "test_expects_not_toequal_behaves_correctly",
+            "test_expecting_string1_to_equal_double1_fails",
             ]
         
         suite = TestSuite()
@@ -99,6 +100,17 @@ class ExpectTests(TestCase):
 
     def test_expects_not_toequal_behaves_correctly(self):
         Expect(1).Not.toEqual(2)
+
+    def test_expecting_string1_to_equal_double1_fails(self):
+        caught = False
+        try:
+            Expect("1").toEqual(1)
+        except AssertionError as ex:
+            caught = True
+            Expect(ex.args[0]).toEqual("Cannot compare instance of <class 'str'> to "
+                                       + "instance of <class 'int'> because their types differ")
+        
+        assert caught, "Expected expect to fail"
 
 if __name__ == "__main__":
     suite = ExpectTests.suite()


### PR DESCRIPTION
This means that Expect(1).toEqual("1") and Expect(1).Not.toEqual("2") will both fail. Types can only be compared if they are the same.
