### PR TITLE
Strings wrapped in more helpful text when tests fail

### DIFF
--- a/src/WellBehavedPython/Expect.py
+++ b/src/WellBehavedPython/Expect.py
@@ -28,7 +28,20 @@ class Expect(BaseExpect):
         self.Not = ExpectNot(actual)
 
     def buildMessage(self, operation, expected):
-        return "Expected {} {} {}".format(self.actual, operation, expected)
+        """Build the message that will be put into the AssertionError
+        if the condition fails. The message will contain the actual
+        values, the expected value and the operation being performed."""
+        formattedActual = self.formatForMessage(self.actual);
+        formattedExpected = self.formatForMessage(expected)
+        return "Expected {} {} {}".format(formattedActual, operation,
+                                          formattedExpected)
+
+    def formatForMessage(self, unformatted):
+        """Perform formatting for special types which need to be formatted
+        differently, e.g. strings to indicate where their start and ends are."""
+        if isinstance(unformatted, str):
+            return "'{}'".format(unformatted)
+        return unformatted
 
     def fail(self, Message = ""):
         raise AssertionError(Message)

--- a/tests/ExpectTests.py
+++ b/tests/ExpectTests.py
@@ -78,7 +78,6 @@ class ExpectTests(TestCase):
         except AssertionError as ex:
             # We use a manual assert here, otherwise we assume that toEqual works
             # in the test that's checking that it works
-            print("exception message was {}".format(ex.args[0]))
             assert ex.args[0] == "Expected 1 to equal 2", ex.args[0]
         
         assert flag, "Expected exception to be thrown"
@@ -94,7 +93,10 @@ class ExpectTests(TestCase):
         except AssertionError as ex:
             # We use a manual assert here. Otherwise we're assuming the code we're
             # testing here is already working. Which would be crazy.
-            assert ex.args[0] == "Expected hello to equal world", ex.args[0]
+            expected = "Expected 'hello' to equal 'world'"
+            actual = ex.args[0]
+            message = "'{}' != '{}'".format(expected, ex.args[0])
+            assert actual == expected, message
         
         assert flag, "Expected exception to be thrown"        
 


### PR DESCRIPTION
Expected 'hello' to equal 'world' rather than Expected hello to equal world
