### PR TITLE
Expect not format strings as well

### DIFF
--- a/src/WellBehavedPython/BaseExpect.py
+++ b/src/WellBehavedPython/BaseExpect.py
@@ -45,4 +45,10 @@ class BaseExpect:
             actualType, expectedType)
         assert actualType == expectedType, message
 
+    def formatForMessage(self, unformatted):
+        """Perform formatting for special types which need to be formatted
+        differently, e.g. strings to indicate where their start and ends are."""
+        if isinstance(unformatted, str):
+            return "'{}'".format(unformatted)
+        return unformatted
 

--- a/src/WellBehavedPython/Expect.py
+++ b/src/WellBehavedPython/Expect.py
@@ -36,13 +36,6 @@ class Expect(BaseExpect):
         return "Expected {} {} {}".format(formattedActual, operation,
                                           formattedExpected)
 
-    def formatForMessage(self, unformatted):
-        """Perform formatting for special types which need to be formatted
-        differently, e.g. strings to indicate where their start and ends are."""
-        if isinstance(unformatted, str):
-            return "'{}'".format(unformatted)
-        return unformatted
-
     def fail(self, Message = ""):
         raise AssertionError(Message)
 

--- a/src/WellBehavedPython/ExpectNot.py
+++ b/src/WellBehavedPython/ExpectNot.py
@@ -28,7 +28,12 @@ class ExpectNot(BaseExpect):
     def buildMessage(self, operation, expected):
         """Builds the message passed to success and failure handling
         methods."""
-        return "Expected {} not {} {}".format(self.actual, operation, expected)
+        formattedActual = self.formatForMessage(self.actual)
+        formattedExpected = self.formatForMessage(expected)
+        return "Expected {} not {} {}".format(formattedActual, operation,
+                                              formattedExpected)
+
+
 
     def fail(self, Message = ""):
         """Indicate a failure.

--- a/tests/ExpectNotTests.py
+++ b/tests/ExpectNotTests.py
@@ -87,7 +87,7 @@ class ExpectNotTests(TestCase):
             message = ex.args[0]
         
         assert raised, "Expected exception to be thrown"
-        Expect(message).toEqual("Expected asdf not to equal asdf")        
+        Expect(message).toEqual("Expected 'asdf' not to equal 'asdf'")        
 
     def test_expecting_string1_not_to_equal_double1_fails(self):
         caught = False


### PR DESCRIPTION
ExpectNot now formats strings for output as well
