### PR TITLE
Expectations factories can be used to create expecters

### DIFF
--- a/src/WellBehavedPython/ExpectationsRegistry.py
+++ b/src/WellBehavedPython/ExpectationsRegistry.py
@@ -35,12 +35,17 @@ class ExpectationsFactory:
         createExpectations: callable object that is used to create
                             an expectations object in isolation."""
 
-        self.createPredicate = createPredicate
-        self.createExpectations = createExpectations
+        self._createPredicate = createPredicate
+        self._createExpectations = createExpectations
 
-    def shouldCreateFor(self, item):
+    def shouldUseFor(self, item):
+        return self._createPredicate(item)
 
-        return self.createPredicate(item)
+    def createExpectations(self, item, strategy, reverseStrategy):
+        reverseExpectations = self._createExpectations(item, reverseStrategy, None)
+        expectations = self._createExpectations(item, strategy, reverseExpectations)
+
+        return expectations
 
 class ExpectationsRegistry:
     pass

--- a/tests/WellBehavedPythonTests/ExpectationsRegistryTests.py
+++ b/tests/WellBehavedPythonTests/ExpectationsRegistryTests.py
@@ -31,7 +31,7 @@ class ExpectationsFactoryTests(TestCase):
         factory = ExpectationsFactory(lambda klass: False, None)
 
         # When
-        result = factory.shouldCreateFor(1)
+        result = factory.shouldUseFor(1)
 
         # Then
         expect(result).toBeFalse()
@@ -41,7 +41,29 @@ class ExpectationsFactoryTests(TestCase):
         factory = ExpectationsFactory(lambda klass: True, None)
 
         # When
-        result = factory.shouldCreateFor(1)
+        result = factory.shouldUseFor(1)
 
         # Then
         expect(result).toBeTrue()
+
+    def test_that_factory_creates_expect_and_expect_not_methods(self):
+        # Where
+        self.createCallCount = 0
+        self.reverser = None
+
+        def create_expecter(actual, strategy, reverser):
+            self.createCallCount += 1
+            if reverser is not None:
+                self.reverser = reverser
+            return 'mockExpecter'
+
+        factory = ExpectationsFactory(lambda item: True, create_expecter)
+        item = 1
+
+        # When
+
+        factory.createExpectations(item, 'mockStrategy', 'mockReverseStrategy')
+
+        # Then
+        expect(self.createCallCount).toEqual(2)
+        expect(self.reverser).toEqual('mockExpecter')


### PR DESCRIPTION
Refactored api.py to use ExpectationsFactories reducing the replciation of the reverse/forward expectations object construction
